### PR TITLE
Increase default gateway pairing session TTL to 10 minutes

### DIFF
--- a/apps/api/src/routes/gateway-pairing.ts
+++ b/apps/api/src/routes/gateway-pairing.ts
@@ -114,7 +114,7 @@ gatewayPairingRouter.post("/start", async (c) => {
 
   const sessionId = crypto.randomUUID();
   const pairCode = randomPairCode(8);
-  const ttlSeconds = body.ttl_seconds ?? 300;
+  const ttlSeconds = body.ttl_seconds ?? 600;
   const expiresAt = Date.now() + (ttlSeconds * 1000);
 
   const stub = getPairingStub(c.env, sessionId);


### PR DESCRIPTION
## Summary
- increase managed gateway pairing default TTL from 300s to 600s
- reduce onboarding failures caused by 5-minute code/session expiry during setup

## Test plan
- [x] Update `apps/api/src/routes/gateway-pairing.ts` default `ttl_seconds`
- [x] Confirm no linter errors for modified file

Made with [Cursor](https://cursor.com)