### PR TITLE
Fix managed auth readiness and agent-id signature verification

### DIFF
--- a/sdks/sdk-go/sigilum/http_signatures.go
+++ b/sdks/sdk-go/sigilum/http_signatures.go
@@ -18,23 +18,46 @@ import (
 var signatureInputPattern = regexp.MustCompile(`^sig1=\(([^)]*)\);created=(\d+);keyid="([^"]+)";alg="([^"]+)";nonce="([^"]+)"$`)
 var signaturePattern = regexp.MustCompile(`^sig1=:([^:]+):$`)
 
-var requiredComponentsNoBody = []string{
-	"@method",
-	"@target-uri",
-	"sigilum-namespace",
-	"sigilum-subject",
-	"sigilum-agent-key",
-	"sigilum-agent-cert",
+var requiredComponentSetsNoBody = [][]string{
+	{
+		"@method",
+		"@target-uri",
+		"sigilum-namespace",
+		"sigilum-subject",
+		"sigilum-agent-key",
+		"sigilum-agent-cert",
+	},
+	{
+		"@method",
+		"@target-uri",
+		"sigilum-namespace",
+		"sigilum-subject",
+		"sigilum-agent-id",
+		"sigilum-agent-key",
+		"sigilum-agent-cert",
+	},
 }
 
-var requiredComponentsWithBody = []string{
-	"@method",
-	"@target-uri",
-	"content-digest",
-	"sigilum-namespace",
-	"sigilum-subject",
-	"sigilum-agent-key",
-	"sigilum-agent-cert",
+var requiredComponentSetsWithBody = [][]string{
+	{
+		"@method",
+		"@target-uri",
+		"content-digest",
+		"sigilum-namespace",
+		"sigilum-subject",
+		"sigilum-agent-key",
+		"sigilum-agent-cert",
+	},
+	{
+		"@method",
+		"@target-uri",
+		"content-digest",
+		"sigilum-namespace",
+		"sigilum-subject",
+		"sigilum-agent-id",
+		"sigilum-agent-key",
+		"sigilum-agent-cert",
+	},
 }
 
 const (
@@ -402,19 +425,26 @@ func containsComponent(components []string, value string) bool {
 }
 
 func hasValidSignedComponentSet(components []string, hasBody bool) bool {
-	expected := requiredComponentsNoBody
+	expectedSets := requiredComponentSetsNoBody
 	if hasBody {
-		expected = requiredComponentsWithBody
+		expectedSets = requiredComponentSetsWithBody
 	}
-	if len(components) != len(expected) {
-		return false
-	}
-	for idx := range expected {
-		if components[idx] != expected[idx] {
-			return false
+	for _, expected := range expectedSets {
+		if len(components) != len(expected) {
+			continue
+		}
+		match := true
+		for idx := range expected {
+			if components[idx] != expected[idx] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func randomUUIDV4() (string, error) {

--- a/sdks/sdk-go/sigilum/http_signatures_test.go
+++ b/sdks/sdk-go/sigilum/http_signatures_test.go
@@ -1,6 +1,8 @@
 package sigilum
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -156,4 +158,80 @@ func TestVerifyFailsOnInvalidSignedComponentSet(t *testing.T) {
 	if !strings.Contains(strings.ToLower(verified.Reason), "component set") {
 		t.Fatalf("expected component-set error, got: %s", verified.Reason)
 	}
+}
+
+func TestVerifyAllowsSignedAgentIDComponentSet(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := InitIdentity(InitIdentityOptions{Namespace: "alice", HomeDir: tmp})
+	if err != nil {
+		t.Fatalf("init identity: %v", err)
+	}
+	identity, err := LoadIdentity(LoadIdentityOptions{Namespace: "alice", HomeDir: tmp})
+	if err != nil {
+		t.Fatalf("load identity: %v", err)
+	}
+
+	buildSignedWithAgentID := func(method string, body []byte) SignedRequest {
+		signed, signErr := SignHTTPRequest(identity, SignRequestInput{
+			URL:     "https://api.sigilum.local/v1/namespaces/alice/claims",
+			Method:  method,
+			Body:    body,
+			Subject: "user-123",
+			Headers: map[string]string{
+				"sigilum-agent-id": "main",
+			},
+		})
+		if signErr != nil {
+			t.Fatalf("sign request: %v", signErr)
+		}
+		signed.Headers["sigilum-agent-id"] = "main"
+
+		parsed, parseErr := parseSignatureInputHeader(signed.Headers["signature-input"])
+		if parseErr != nil {
+			t.Fatalf("parse signature input: %v", parseErr)
+		}
+		components := []string{"@method", "@target-uri", "sigilum-namespace", "sigilum-subject", "sigilum-agent-id", "sigilum-agent-key", "sigilum-agent-cert"}
+		if len(body) > 0 {
+			components = []string{"@method", "@target-uri", "content-digest", "sigilum-namespace", "sigilum-subject", "sigilum-agent-id", "sigilum-agent-key", "sigilum-agent-cert"}
+		}
+		sigParams := signatureParams(components, parsed.Created, parsed.KeyID, parsed.Nonce)
+		base, baseErr := signingBase(components, normalizeMethod(signed.Method), normalizeTargetURI(signed.URL), normalizeHeaders(signed.Headers), sigParams)
+		if baseErr != nil {
+			t.Fatalf("signing base: %v", baseErr)
+		}
+		private := ed25519.NewKeyFromSeed(identity.PrivateKey)
+		signature := ed25519.Sign(private, base)
+		signed.Headers["signature-input"] = "sig1=" + sigParams
+		signed.Headers["signature"] = "sig1=:" + base64.StdEncoding.EncodeToString(signature) + ":"
+		return signed
+	}
+
+	t.Run("no body", func(t *testing.T) {
+		signed := buildSignedWithAgentID("GET", nil)
+		verified := VerifyHTTPSignature(VerifySignatureInput{
+			URL:               signed.URL,
+			Method:            signed.Method,
+			Headers:           signed.Headers,
+			ExpectedNamespace: "alice",
+			ExpectedSubject:   "user-123",
+		})
+		if !verified.Valid {
+			t.Fatalf("expected valid signature with sigilum-agent-id, got: %s (%s)", verified.Code, verified.Reason)
+		}
+	})
+
+	t.Run("with body", func(t *testing.T) {
+		signed := buildSignedWithAgentID("POST", []byte(`{"action":"approve"}`))
+		verified := VerifyHTTPSignature(VerifySignatureInput{
+			URL:               signed.URL,
+			Method:            signed.Method,
+			Headers:           signed.Headers,
+			Body:              signed.Body,
+			ExpectedNamespace: "alice",
+			ExpectedSubject:   "user-123",
+		})
+		if !verified.Valid {
+			t.Fatalf("expected valid signature with sigilum-agent-id body profile, got: %s (%s)", verified.Code, verified.Reason)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- allow Go signature verification to accept both valid signed component profiles (with and without `sigilum-agent-id`)
- fail `openclaw install --mode managed` when no service API key can be sourced and runtime has no existing key files
- upgrade `sigilum doctor` managed checks to fail when runtime service API keys are missing
- add regression tests for `sigilum-agent-id` signed component sets

## Why
Managed installs could report success while gateway auth was non-functional due to missing service API key material, and signed requests that included `sigilum-agent-id` could fail verifier component validation depending on verifier profile strictness.

## Validation
- `go test ./sigilum -run "TestVerifyAllowsSignedAgentIDComponentSet|TestSignAndVerify|TestVerifyFailsOnInvalidSignedComponentSet"` (in `sdks/sdk-go`)
- `go test ./cmd/sigilum-gateway -run "TestExtractSigilumIdentityAllowsSignedAgentID|TestExtractSigilumIdentityRejectsUnsignedAgentID|TestWriteProxyAuthRequiredMarkdown|TestEnforceClaimAuthorizationNilCacheUsesClaimsUnavailableCode|TestEnforceClaimAuthorizationLookupFailureUsesClaimsLookupFailedCode"` (in `apps/gateway/service`)
- `go test ./internal/claims -run "TestSubmitClaimPostsClaimPayload|TestSubmitClaimRequiresServiceAPIKey"` (in `apps/gateway/service`)
- `bash -n openclaw/install-openclaw-sigilum.sh`
- `bash -n scripts/sigilum-doctor.sh`