### PR TITLE
Fix managed service key fallback for ~/.sigilum-workspace

### DIFF
--- a/apps/gateway/service/cmd/sigilum-gateway/main_test.go
+++ b/apps/gateway/service/cmd/sigilum-gateway/main_test.go
@@ -323,6 +323,29 @@ func TestResolveServiceAPIKeyFallsBackToFile(t *testing.T) {
 	}
 }
 
+func TestResolveServiceAPIKeyFallsBackToHomeSigilumWorkspaceFile(t *testing.T) {
+	isolateServiceKeyHome(t)
+	t.Setenv("SIGILUM_SERVICE_API_KEY_DEMO_SERVICE_GATEWAY", "")
+	t.Setenv("SIGILUM_HOME", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("lookup user home dir: %v", err)
+	}
+	keyDir := filepath.Join(home, ".sigilum-workspace")
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatalf("create key dir: %v", err)
+	}
+	keyFile := filepath.Join(keyDir, "service-api-key-demo-service-gateway")
+	if err := os.WriteFile(keyFile, []byte("workspace-key\n"), 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	if got := resolveServiceAPIKey("demo-service-gateway", "", ""); got != "workspace-key" {
+		t.Fatalf("expected workspace key fallback, got %q", got)
+	}
+}
+
 func TestResolveServiceAPIKeyPrefersFileOverDefault(t *testing.T) {
 	isolateServiceKeyHome(t)
 	t.Setenv("SIGILUM_SERVICE_API_KEY_DEMO_SERVICE_GATEWAY", "")

--- a/apps/gateway/service/cmd/sigilum-gateway/service_key_helpers.go
+++ b/apps/gateway/service/cmd/sigilum-gateway/service_key_helpers.go
@@ -42,6 +42,7 @@ func candidateServiceKeyHomes(explicitHome string) []string {
 		candidates = append(candidates, value)
 	}
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		candidates = append(candidates, filepath.Join(home, ".sigilum-workspace"))
 		candidates = append(candidates, filepath.Join(home, ".sigilum"))
 		candidates = append(candidates, filepath.Join(home, ".openclaw", "workspace", ".sigilum"))
 		candidates = append(candidates, filepath.Join(home, ".openclaw", ".sigilum"))

--- a/openclaw/install-openclaw-sigilum.sh
+++ b/openclaw/install-openclaw-sigilum.sh
@@ -455,6 +455,7 @@ detect_service_key_source_home() {
   fi
   candidates+=(
     "${ROOT_DIR}/.sigilum-workspace"
+    "${HOME}/.sigilum-workspace"
     "${HOME}/.sigilum"
     "${OPENCLAW_HOME}/workspace/.sigilum"
   )


### PR DESCRIPTION
## Summary
- add ~/.sigilum-workspace to OpenClaw installer service-key source discovery
- add ~/.sigilum-workspace to gateway runtime service-key home fallbacks
- add a gateway regression test proving fallback resolves from ~/.sigilum-workspace/service-api-key-[connection-id]

## Why
Managed pairing can provision service API keys into ~/.sigilum-workspace. The installer and gateway were not checking this location, causing signature verification failures (AUTH_SIGNATURE_INVALID) before claim flow.

## Validation
- go test ./cmd/sigilum-gateway -run 'TestResolveServiceAPIKey.*'
- go test ./cmd/sigilum-gateway
- bash -n openclaw/install-openclaw-sigilum.sh
